### PR TITLE
UI: Create Reusable CreateNoticeSheet Widget #45

### DIFF
--- a/lib/data/repositories/notice/notices_repository_firestore.dart
+++ b/lib/data/repositories/notice/notices_repository_firestore.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:lonepeak/data/repositories/notice/notices_repository.dart';
 import 'package:lonepeak/data/services/notices/notices_service.dart';
 import 'package:lonepeak/domain/models/metadata.dart';
@@ -99,16 +100,16 @@ class NoticesRepositoryFirestore extends NoticesRepository {
   @override
   Future<Result<Notice>> toggleLike(String noticeId) async {
     final estateId = await _appState.getEstateId();
-    final userEmail = _appState.getUserId();
+    final userId = FirebaseAuth.instance.currentUser?.uid;
 
     if (estateId == null) {
       return Result.failure('Estate ID is null');
     }
 
-    if (userEmail == null) {
-      return Result.failure('User email is null');
+    if (userId == null) {
+      return Result.failure('User ID is null');
     }
 
-    return _noticesService.likeNotice(estateId, noticeId, userEmail);
+    return _noticesService.likeNotice(estateId, noticeId, userId);
   }
 }

--- a/lib/domain/models/notice.dart
+++ b/lib/domain/models/notice.dart
@@ -66,13 +66,13 @@ class Notice {
 
 enum NoticeType {
   general('general'),
-  urgent('urgent'),
+  alert('alert'),
   event('event');
 
   static NoticeType fromString(String type) {
     switch (type) {
-      case 'urgent':
-        return NoticeType.urgent;
+      case 'alert':
+        return NoticeType.alert;
       case 'event':
         return NoticeType.event;
       default:
@@ -81,6 +81,5 @@ enum NoticeType {
   }
 
   final String name;
-
   const NoticeType(this.name);
 }

--- a/lib/ui/core/themes/themes.dart
+++ b/lib/ui/core/themes/themes.dart
@@ -5,6 +5,7 @@ abstract final class AppColors {
   static const Color black = Color.fromARGB(196, 0, 0, 0);
   static const Color white = Color.fromARGB(255, 249, 252, 254);
   static const Color lightblack = Color.fromARGB(156, 0, 0, 0);
+  static const Color red = Color.fromARGB(255, 238, 68, 67);
   static const Color black50 = Color.from(
     alpha: 0.5,
     red: 0,
@@ -23,7 +24,7 @@ abstract final class AppThemes {
       secondary: Colors.grey,
       brightness: Brightness.light,
     ),
-    cardTheme: CardTheme(
+    cardTheme: CardThemeData(
       color: Colors.white,
       elevation: 0.3,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
@@ -63,7 +64,7 @@ abstract final class AppThemes {
       surface: const Color(0xFF121212),
       onSurface: Colors.white.withAlpha(225),
     ),
-    cardTheme: CardTheme(
+    cardTheme: CardThemeData(
       color: const Color(0xFF1E1E1E),
       elevation: 0.3,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),

--- a/lib/ui/estate_notices/widgets/create_notice_sheet.dart
+++ b/lib/ui/estate_notices/widgets/create_notice_sheet.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lonepeak/domain/models/notice.dart';
+import 'package:lonepeak/ui/core/themes/themes.dart';
+import 'package:lonepeak/ui/core/widgets/app_buttons.dart';
+import 'package:lonepeak/ui/estate_notices/widgets/notice_color.dart';
+
+class CreateNoticeSheet extends ConsumerStatefulWidget {
+  final void Function(Notice notice) onSubmit;
+  final NoticeType? initialType;
+
+  const CreateNoticeSheet({
+    required this.onSubmit,
+    this.initialType,
+    super.key,
+  });
+
+  @override
+  ConsumerState<CreateNoticeSheet> createState() => _CreateNoticeSheetState();
+}
+
+class _CreateNoticeSheetState extends ConsumerState<CreateNoticeSheet> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _contentController = TextEditingController();
+  late NoticeType _selectedType;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedType = widget.initialType ?? NoticeType.general;
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _contentController.dispose();
+    super.dispose();
+  }
+
+  void _submitForm() {
+    if (!_formKey.currentState!.validate()) return;
+
+    final newNotice = Notice(
+      title: _titleController.text.trim(),
+      message: _contentController.text.trim(),
+      type: _selectedType,
+    );
+    widget.onSubmit(newNotice);
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isAlert = widget.initialType == NoticeType.alert;
+    final titleText = isAlert ? 'Create New Alert' : 'Create New Notice';
+    final buttonText = isAlert ? 'Send Alert' : 'Create Notice';
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 16,
+        right: 16,
+        top: 16,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+      ),
+      child: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Center(
+                      child: Text(
+                        titleText,
+                        style: AppStyles.titleTextSmall(context),
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _titleController,
+                textCapitalization: TextCapitalization.sentences,
+                decoration: const InputDecoration(
+                  labelText: 'Title',
+                  hintText: 'e.g. Community Meeting',
+                  border: OutlineInputBorder(),
+                ),
+                validator:
+                    (value) =>
+                        value == null || value.trim().isEmpty
+                            ? 'Title is required'
+                            : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _contentController,
+                textCapitalization: TextCapitalization.sentences,
+                maxLines: 4,
+                decoration: const InputDecoration(
+                  labelText: 'Message',
+                  hintText: 'Describe the announcement details...',
+                  border: OutlineInputBorder(),
+                ),
+                validator:
+                    (value) =>
+                        value == null || value.trim().isEmpty
+                            ? 'Message is required'
+                            : null,
+              ),
+              const SizedBox(height: 16),
+              widget.initialType == null
+                  ? _buildTypeSelector()
+                  : _buildReadOnlyType(),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: AppElevatedButton(
+                  onPressed: _submitForm,
+                  buttonText: buttonText,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTypeSelector() {
+    return Wrap(
+      spacing: 8.0,
+      children:
+          NoticeType.values.where((type) => type != NoticeType.alert).map((
+            type,
+          ) {
+            final chipColor = NoticeTypeUI.getCategoryColor(type);
+            final chipLabel =
+                type.name[0].toUpperCase() + type.name.substring(1);
+            return ChoiceChip(
+              label: Text(
+                chipLabel,
+                style: TextStyle(
+                  color: chipColor,
+                  fontSize: 13,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              selected: _selectedType == type,
+              backgroundColor: chipColor.withAlpha(25),
+              selectedColor: chipColor.withAlpha(77),
+              side: BorderSide.none,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12.0),
+              ),
+              onSelected: (isSelected) {
+                if (isSelected) {
+                  setState(() => _selectedType = type);
+                }
+              },
+            );
+          }).toList(),
+    );
+  }
+
+  Widget _buildReadOnlyType() {
+    final chipColor = NoticeTypeUI.getCategoryColor(_selectedType);
+    final chipLabel =
+        _selectedType.name[0].toUpperCase() + _selectedType.name.substring(1);
+    return InputDecorator(
+      decoration: const InputDecoration(
+        labelText: 'Type',
+        border: OutlineInputBorder(),
+        contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+      ),
+      child: Text(
+        chipLabel,
+        style: TextStyle(
+          color: chipColor,
+          fontWeight: FontWeight.bold,
+          fontSize: 16,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/estate_notices/widgets/estate_notices_screen.dart
+++ b/lib/ui/estate_notices/widgets/estate_notices_screen.dart
@@ -1,15 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lonepeak/domain/models/notice.dart';
-import 'package:lonepeak/ui/core/themes/themes.dart';
-import 'package:lonepeak/ui/core/widgets/app_buttons.dart';
-import 'package:lonepeak/ui/core/widgets/app_inputs.dart';
 import 'package:lonepeak/ui/core/widgets/appbar_action_button.dart';
 import 'package:lonepeak/ui/core/widgets/appbar_title.dart';
 import 'package:lonepeak/ui/estate_notices/view_models/estate_notices_viewmodel.dart';
-import 'package:lonepeak/ui/core/widgets/notice_card.dart';
-import 'package:lonepeak/ui/estate_notices/widgets/notice_color.dart';
 import 'package:lonepeak/ui/core/ui_state.dart';
+import 'package:lonepeak/ui/estate_notices/widgets/create_notice_sheet.dart';
+import 'package:lonepeak/ui/estate_notices/widgets/notice_card.dart';
 
 class EstateNoticesScreen extends ConsumerStatefulWidget {
   const EstateNoticesScreen({super.key});
@@ -23,19 +19,19 @@ class _EstateNoticesScreenState extends ConsumerState<EstateNoticesScreen> {
   @override
   void initState() {
     super.initState();
-    Future.microtask(
-      () => ref.read(estateNoticesViewModelProvider.notifier).getNotices(),
-    );
+    Future.microtask(() {
+      ref.read(estateNoticesViewModelProvider.notifier).getNotices();
+    });
   }
 
   @override
   Widget build(BuildContext context) {
+    final viewModel = ref.read(estateNoticesViewModelProvider.notifier);
     final state = ref.watch(estateNoticesViewModelProvider);
-    final notices = ref.read(estateNoticesViewModelProvider.notifier).notices;
 
     return Scaffold(
       appBar: AppBar(
-        title: AppbarTitle(text: 'Notices'),
+        title: const AppbarTitle(text: 'Notices'),
         actions: [
           AppbarActionButton(
             icon: Icons.notification_add,
@@ -44,30 +40,53 @@ class _EstateNoticesScreenState extends ConsumerState<EstateNoticesScreen> {
         ],
       ),
       body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              if (state is UIStateLoading)
-                const Center(child: CircularProgressIndicator())
-              else if (state is UIStateFailure)
-                Center(child: Text('Error: ${state.error}'))
-              else
-                ...notices.map((notice) => NoticeCard(notice: notice)),
-            ],
-          ),
+        child: RefreshIndicator(
+          onRefresh: viewModel.getNotices,
+          child: _buildBody(state, viewModel),
         ),
       ),
     );
   }
 
-  void _showCreateNoticeBottomSheet(BuildContext context) {
-    final titleController = TextEditingController();
-    final contentController = TextEditingController();
-    NoticeType selectedType = NoticeType.general;
-    final formKey = GlobalKey<FormState>();
+  Widget _buildBody(UIState state, EstateNoticesViewmodel viewModel) {
+    if (state is UIStateLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
 
+    if (state is UIStateFailure) {
+      return Center(child: Text(state.error));
+    }
+
+    if (state is UIStateSuccess) {
+      final notices = viewModel.notices;
+
+      if (notices.isEmpty) {
+        return const Center(child: Text('No notices have been posted yet.'));
+      }
+
+      return ListView.builder(
+        padding: const EdgeInsets.all(16.0),
+        itemCount: notices.length,
+        itemBuilder: (context, index) {
+          final notice = notices[index];
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 16.0),
+            child: NoticeCard(
+              notice: notice,
+              onLike:
+                  notice.id != null
+                      ? () => viewModel.toggleLike(notice.id!)
+                      : () {},
+            ),
+          );
+        },
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+
+  void _showCreateNoticeBottomSheet(BuildContext context) {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
@@ -75,134 +94,12 @@ class _EstateNoticesScreenState extends ConsumerState<EstateNoticesScreen> {
         borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
       ),
       builder: (context) {
-        return StatefulBuilder(
-          builder: (context, setState) {
-            return Padding(
-              padding: EdgeInsets.only(
-                left: 16,
-                right: 16,
-                top: 16,
-                bottom: MediaQuery.of(context).viewInsets.bottom + 16,
-              ),
-              child: SingleChildScrollView(
-                child: Form(
-                  key: formKey,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          const SizedBox(
-                            width: 24,
-                          ), // Placeholder for alignment
-                          Text(
-                            'Create New Notice',
-                            style: AppStyles.titleTextSmall(context),
-                          ),
-                          IconButton(
-                            icon: const Icon(Icons.close),
-                            onPressed: () => Navigator.of(context).pop(),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 8),
-                      Center(
-                        child: Text(
-                          'Create a new notification or announcement for all estate members.',
-                          style: AppStyles.subtitleText(context),
-                        ),
-                      ),
-                      const SizedBox(height: 16),
-                      AppTextInput(
-                        controller: titleController,
-                        labelText: 'Title',
-                        hintText: 'e.g. Community Meeting',
-                        required: true,
-                        errorText: 'Title is required',
-                      ),
-                      const SizedBox(height: 16),
-                      AppTextInput(
-                        controller: contentController,
-                        labelText: 'Content',
-                        maxLines: 3,
-                        hintText: 'Describe the announcement details...',
-                        required: true,
-                        errorText: 'Message is required',
-                      ),
-                      const SizedBox(height: 16),
-                      Wrap(
-                        spacing: 8.0,
-                        children:
-                            NoticeType.values.map((type) {
-                              final chipColor = NoticeTypeUI.getCategoryColor(
-                                type,
-                              );
-                              final chipLabel =
-                                  type.name[0].toUpperCase() +
-                                  type.name.substring(1);
-                              return ChoiceChip(
-                                label: Text(
-                                  chipLabel,
-                                  style: TextStyle(
-                                    color: chipColor,
-                                    fontSize: 13,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                                selected: selectedType == type,
-                                backgroundColor: chipColor.withAlpha(50),
-                                selectedColor: chipColor.withAlpha(50),
-                                side: BorderSide.none,
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(12.0),
-                                ),
-                                onSelected: (isSelected) {
-                                  if (isSelected) {
-                                    setState(() {
-                                      selectedType = type;
-                                    });
-                                  }
-                                },
-                              );
-                            }).toList(),
-                      ),
-                      const SizedBox(height: 32),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          AppElevatedButton(
-                            onPressed: () {
-                              if (!formKey.currentState!.validate()) {
-                                return;
-                              }
-                              final newNotice = Notice(
-                                title: titleController.text,
-                                message: contentController.text,
-                                type: selectedType,
-                              );
-                              final notifier = ref.read(
-                                estateNoticesViewModelProvider.notifier,
-                              );
-                              notifier.addNotice(newNotice);
-                              notifier.getNotices();
-                              Navigator.of(context).pop();
-                            },
-                            padding: const EdgeInsets.symmetric(
-                              vertical: 8,
-                              horizontal: 12,
-                            ),
-                            buttonText: 'Create',
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-                    ],
-                  ),
-                ),
-              ),
-            );
+        return CreateNoticeSheet(
+          onSubmit: (notice) {
+            final notifier = ref.read(estateNoticesViewModelProvider.notifier);
+            notifier.addNotice(notice).then((_) {
+              notifier.getNotices();
+            });
           },
         );
       },

--- a/lib/ui/estate_notices/widgets/notice_card.dart
+++ b/lib/ui/estate_notices/widgets/notice_card.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:lonepeak/domain/models/notice.dart';
+import 'package:lonepeak/ui/estate_notices/widgets/notice_color.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class NoticeCard extends StatelessWidget {
+  final Notice notice;
+  final VoidCallback onLike;
+
+  const NoticeCard({super.key, required this.notice, required this.onLike});
+
+  @override
+  Widget build(BuildContext context) {
+    final chipColor = NoticeTypeUI.getCategoryColor(notice.type);
+    final chipLabel =
+        notice.type.name[0].toUpperCase() + notice.type.name.substring(1);
+    final date = DateFormat(
+      'MMM d, yyyy • hh:mm a',
+    ).format(notice.metadata?.createdAt?.toDate() ?? DateTime.now());
+    final createdBy = notice.metadata?.createdBy ?? 'Unknown';
+
+    final currentUserId = FirebaseAuth.instance.currentUser?.uid ?? '';
+    final isLiked = notice.likedBy.contains(currentUserId);
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      elevation: 3,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Chip(
+                  label: Text(
+                    chipLabel,
+                    style: TextStyle(
+                      color: chipColor,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  backgroundColor: chipColor.withAlpha(30),
+                  side: BorderSide.none,
+                ),
+                const Spacer(),
+                IconButton(
+                  icon: Icon(
+                    isLiked ? Icons.thumb_up : Icons.thumb_up_outlined,
+                    color: isLiked ? Colors.blue : null,
+                  ),
+                  onPressed: onLike,
+                  tooltip: isLiked ? 'Liked' : 'Like',
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              notice.title,
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 4),
+            Text(notice.message, style: Theme.of(context).textTheme.bodyMedium),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  createdBy,
+                  style: TextStyle(
+                    fontStyle: FontStyle.italic,
+                    color: Colors.grey[600],
+                  ),
+                ),
+                Text(
+                  date,
+                  style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/estate_notices/widgets/notice_color.dart
+++ b/lib/ui/estate_notices/widgets/notice_color.dart
@@ -4,23 +4,23 @@ import 'package:lonepeak/domain/models/notice.dart';
 abstract class NoticeTypeUI {
   static Color getCategoryColor(NoticeType type) {
     switch (type) {
-      case NoticeType.urgent:
-        return Colors.red.withValues(alpha: 0.65);
+      case NoticeType.alert:
+        return Colors.red.withAlpha(200);
       case NoticeType.general:
-        return Colors.blue.withValues(alpha: 0.8);
+        return Colors.blue.withAlpha(200);
       case NoticeType.event:
-        return Colors.green.withValues(alpha: 0.7);
+        return Colors.green.withAlpha(200);
     }
   }
 
   static IconData getCategoryIcon(NoticeType type) {
     switch (type) {
-      case NoticeType.urgent:
+      case NoticeType.alert:
         return Icons.warning_amber_outlined;
       case NoticeType.general:
         return Icons.info_outline;
       case NoticeType.event:
-        return Icons.group_outlined;
+        return Icons.event_note_outlined;
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -372,10 +372,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -705,10 +705,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
- Extracted the notice creation form into a reusable `CreateNoticeSheet` widget
- Added support for `onNoticeCreated` callback and optional `initialType`
- Included validation for title and message fields
- Updated `EstateNoticesScreen` to use the new reusable sheet
